### PR TITLE
Merge #44 into main

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export const EXPLORER_URLS: { [key: number]: string } = {
 
 export const DEFAULT_PC_URLS: { [key: number]: string } = {
   [base.id]: 'https://mainnet.base.org',
-  [gnosis.id]: 'https://gnosischain-mainnet.rpc.porters.xyz/dI5OQj5TLG',
+  [gnosis.id]: 'https://rpc.gnosis.gateway.fm',
   [sepolia.id]: 'https://rpc.sepolia.org'
 };
 


### PR DESCRIPTION
This pull request includes a small change to the `src/config.ts` file. The change updates the URL for the Gnosis chain in the `DEFAULT_PC_URLS` object.

* [`src/config.ts`](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L37-R37): Updated the URL for the Gnosis chain from 'https://gnosischain-mainnet.rpc.porters.xyz/dI5OQj5TLG' to 'https://rpc.gnosis.gateway.fm'.