### PR TITLE
Use node v18 for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 WORKDIR /src
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the base Docker image to use Node 18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->