### PR TITLE
fix: update Forge emoji name

### DIFF
--- a/src/features/roleClaim.ts
+++ b/src/features/roleClaim.ts
@@ -67,7 +67,7 @@ export const roleClaim = (client: Client) => {
       dwarf: 'AngryDwarf (Treasury)',
       druid: 'Druid (Data Science/Analyst)',
       wizard: 'Wizard (Smart Contracts)',
-      hammer_pick: 'Forge (updates)'
+      '⚒️': 'Forge (updates)'
     };
 
     // const channel = client.channels.cache.get(startHereChannelID);


### PR DESCRIPTION
This pull request includes a small change to the `roleClaim` function in the `src/features/roleClaim.ts` file. The change updates the key for the "Forge (updates)" role from `hammer_pick` to the emoji `⚒️`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the emoji displayed for the "Forge (updates)" role to use the Unicode symbol instead of a text identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->