### PR TITLE
fix: only remove random emojis in start-here channel

### DIFF
--- a/src/features/roleClaim.ts
+++ b/src/features/roleClaim.ts
@@ -92,7 +92,10 @@ export const roleClaim = (client: Client) => {
         reaction.message.channel.id === forgeChannelId
       ) {
         if (!reaction.emoji.name) return;
-        if (!(reaction.emoji.name in emojis)) {
+        if (
+          !(reaction.emoji.name in emojis) &&
+          reaction.message.channel.id === startHereChannelId
+        ) {
           reaction.users.remove(user.id);
         } else {
           handleReaction(reaction, user, true, emojis);


### PR DESCRIPTION
This pull request updates the logic in the `roleClaim` function within `src/features/roleClaim.ts` to refine the conditions under which a reaction is removed. The key change ensures that reactions are only removed if they occur in the `startHereChannelId` channel and the emoji is not in the `emojis` list.

### Key Change:
* [`src/features/roleClaim.ts`](diffhunk://#diff-4debe9a3af09c9d3d713f3386242e23c6acda757e4b89a8e99f86da2742f1daeL95-R98): Updated the conditional logic in the `roleClaim` function to include an additional check for `reaction.message.channel.id === startHereChannelId` when determining if a reaction should be removed. This ensures that reactions are handled more specifically based on the channel context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid emoji reactions, ensuring users are only removed for invalid reactions in specific channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->